### PR TITLE
Implement whistleblower update notifications

### DIFF
--- a/backend/globaleaks/handlers/recipient/rtip.py
+++ b/backend/globaleaks/handlers/recipient/rtip.py
@@ -18,7 +18,7 @@ from globaleaks.handlers.admin.notification import db_get_notification
 from globaleaks.handlers.base import BaseHandler
 from globaleaks.handlers.operation import OperationHandler
 from globaleaks.handlers.whistleblower.submission import db_create_receivertip, decrypt_tip
-from globaleaks.handlers.whistleblower.wbtip import db_notify_report_update
+from globaleaks.handlers.whistleblower.wbtip import db_notify_report_update, db_notify_wb_tip_update
 from globaleaks.handlers.user import user_serialize_user
 from globaleaks.models import serializers
 from globaleaks.orm import db_get, db_del, db_log, transact
@@ -550,6 +550,8 @@ def update_tip_submission_status(session, tid, user_id, rtip_id, status_id, subs
                                models.ReceiverTip.receiver_id != user_id,
                                models.ReceiverTip.last_notification < models.ReceiverTip.last_access):
         db_notify_report_update(session, user, rtip, itip)
+
+    db_notify_wb_tip_update(session, itip)
 
     db_update_submission_status(session, tid, user_id, itip, status_id, substatus_id)
 

--- a/backend/globaleaks/handlers/whistleblower/submission.py
+++ b/backend/globaleaks/handlers/whistleblower/submission.py
@@ -125,6 +125,32 @@ def db_set_internaltip_data(session, itip_id, key, value, date=None):
     return itd
 
 
+def db_set_or_update_internaltip_data(session, itip_id, key, value, date=None):
+    itd = session.query(models.InternalTipData) \
+              .filter(models.InternalTipData.internaltip_id == itip_id,
+                      models.InternalTipData.key == key).one_or_none()
+
+    if itd is None:
+        itd = models.InternalTipData()
+        itd.internaltip_id = itip_id
+        itd.key = key
+        if date:
+            itd.creation_date = date
+        session.add(itd)
+
+    itd.value = value
+    return itd
+
+
+def db_get_internaltip_data(session, itip_id, key):
+    itd = session.query(models.InternalTipData.value) \
+              .filter(models.InternalTipData.internaltip_id == itip_id,
+                      models.InternalTipData.key == key).one_or_none()
+    if itd is None:
+        return None
+    return itd[0]
+
+
 def db_assign_submission_progressive(session, tid):
     counter = session.query(models.Config).filter(models.Config.tid == tid, models.Config.var_name == 'counter_submissions').one()
     counter.value += 1

--- a/backend/globaleaks/handlers/whistleblower/wbtip.py
+++ b/backend/globaleaks/handlers/whistleblower/wbtip.py
@@ -12,7 +12,8 @@ from globaleaks.handlers.admin.notification import db_get_notification
 from globaleaks.handlers.base import BaseHandler
 from globaleaks.handlers.whistleblower.submission import decrypt_tip, \
     db_set_internaltip_answers, db_get_questionnaire, \
-    db_archive_questionnaire_schema, db_set_internaltip_data
+    db_archive_questionnaire_schema, db_set_internaltip_data, \
+    db_set_or_update_internaltip_data, db_get_internaltip_data
 from globaleaks.handlers.user import user_serialize_user
 from globaleaks.models import serializers
 from globaleaks.orm import db_get, transact
@@ -62,6 +63,36 @@ def db_notify_recipients_of_tip_update(session, itip_id):
         db_notify_report_update(session, user, rtip, itip)
 
 
+def db_notify_wb_tip_update(session, itip):
+    email = db_get_internaltip_data(session, itip.id, 'contact_email')
+    if not email:
+        return
+
+    language = State.tenants[itip.tid].cache.default_language
+    data = {
+      'type': 'tip_update',
+      'user': {
+          'mail_address': email,
+          'name': 'Whistleblower',
+          'username': '',
+          'language': language
+      },
+      'node': db_admin_serialize_node(session, itip.tid, language),
+      'tip': serializers.serialize_wbtip(session, itip, language),
+    }
+
+    data['notification'] = db_get_notification(session, itip.tid, language)
+
+    subject, body = Templating().get_mail_subject_and_body(data)
+
+    session.add(models.Mail({
+        'address': email,
+        'subject': subject,
+        'body': body,
+        'tid': itip.tid
+    }))
+
+
 def db_get_wbtip(session, itip_id, language):
     itip = db_get(session, models.InternalTip, models.InternalTip.id == itip_id)
 
@@ -98,6 +129,17 @@ def create_comment(session, tid, user_id, content):
     ret['content'] = content
 
     return ret
+
+
+@transact
+def set_contact_email(session, tid, user_id, contact_email):
+    itip = db_get(session,
+                  models.InternalTip,
+                  (models.InternalTip.id == user_id,
+                   models.InternalTip.status != 'closed',
+                   models.InternalTip.tid == tid))
+
+    db_set_or_update_internaltip_data(session, itip.id, 'contact_email', contact_email)
 
 
 @transact
@@ -312,3 +354,14 @@ class WBTipAdditionalQuestionnaire(BaseHandler):
                                                       self.session.user_id,
                                                       request['answers'],
                                                       self.request.language)
+
+
+class WBTipContactEmail(BaseHandler):
+    """Allow the whistleblower to store a contact email"""
+    check_roles = 'whistleblower'
+
+    def post(self):
+        request = self.validate_request(self.request.content.read(), requests.ContactEmailDesc)
+        return set_contact_email(self.request.tid,
+                                 self.session.user_id,
+                                 request['contact_email'])

--- a/backend/globaleaks/rest/api.py
+++ b/backend/globaleaks/rest/api.py
@@ -94,6 +94,7 @@ api_spec = [
     ('/api/whistleblower/wbtip/wbfiles', whistleblower.wbtip.WhistleblowerFileDownload, r'/api/whistleblower/wbtip/wbfiles/' + uuid_regexp),
     ('/api/whistleblower/wbtip/identity', whistleblower.wbtip.WBTipIdentityHandler),
     ('/api/whistleblower/wbtip/fillform', whistleblower.wbtip.WBTipAdditionalQuestionnaire),
+    ('/api/whistleblower/wbtip/contactemail', whistleblower.wbtip.WBTipContactEmail),
 
     # Custodian Handlers
     ('/api/custodian/iars', custodian.IdentityAccessRequestsCollection),

--- a/backend/globaleaks/rest/requests.py
+++ b/backend/globaleaks/rest/requests.py
@@ -191,6 +191,10 @@ WhisleblowerIdentityAnswers = {
     'identity_field_answers': dict
 }
 
+ContactEmailDesc = {
+    'contact_email': email_regexp
+}
+
 AdminNodeDesc = {
     'name': str,
     'description': str,

--- a/client/app/assets/data/l10n/en.json
+++ b/client/app/assets/data/l10n/en.json
@@ -593,6 +593,8 @@
   "Report updated": "Report updated",
   "This email is to remind you the presence of unread or updated reports.": "This email is to remind you the presence of unread or updated reports.",
   "Reminder about unread or updated reports": "Reminder about unread or updated reports",
+  "Manage notifications": "Manage notifications",
+  "Contact email": "Contact email",
   "Role: {Role}": "Role: {Role}",
   "Password: {Password}": "Password: {Password}"
 }

--- a/client/app/src/models/receiver/receiver-tip-data.ts
+++ b/client/app/src/models/receiver/receiver-tip-data.ts
@@ -70,6 +70,7 @@ export interface Data {
   whistleblower_identity_provided: boolean;
   whistleblower_identity: WhistleblowerIdentity;
   whistleblower_identity_date: string;
+  contact_email?: string;
 }
 
 export interface Context {

--- a/client/app/src/models/whistleblower/wb-tip-data.ts
+++ b/client/app/src/models/whistleblower/wb-tip-data.ts
@@ -135,6 +135,7 @@ export class Receiver {
 export class Data {
   whistleblower_identity: WhistleblowerIdentity;
   whistleblower_identity_provided: boolean = false;
+  contact_email?: string;
 }
 
 export interface MsgReceiversSelector {

--- a/client/app/src/pages/whistleblower/tippage/tippage.component.html
+++ b/client/app/src/pages/whistleblower/tippage/tippage.component.html
@@ -46,6 +46,11 @@
     </div>
     <div class="row">
       <div class="col-md-12">
+        <src-tip-contact-email></src-tip-contact-email>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
         @if (wbTipService) {
           <src-tip-comments [tipService]="wbTipService" [key]="'public'"></src-tip-comments>
         }

--- a/client/app/src/pages/whistleblower/tippage/tippage.component.ts
+++ b/client/app/src/pages/whistleblower/tippage/tippage.component.ts
@@ -19,6 +19,7 @@ import {WhistleblowerIdentityComponent} from "@app/shared/partials/whistleblower
 import {TipFilesWhistleblowerComponent} from "@app/shared/partials/tip-files-whistleblower/tip-files-whistleblower.component";
 import {WidgetWbFilesComponent} from "@app/shared/partials/widget-wbfiles/widget-wb-files.component";
 import {TipCommentsComponent} from "@app/shared/partials/tip-comments/tip-comments.component";
+import {TipContactEmailComponent} from "@app/shared/partials/tip-contact-email/tip-contact-email.component";
 import {TranslateModule} from "@ngx-translate/core";
 import {TranslatorPipe} from "@app/shared/pipes/translate";
 
@@ -26,7 +27,7 @@ import {TranslatorPipe} from "@app/shared/pipes/translate";
     selector: "src-tippage",
     templateUrl: "./tippage.component.html",
     standalone: true,
-    imports: [TipAdditionalQuestionnaireInviteComponent, TipInfoComponent, TipReceiverListComponent, NgbTooltipModule, NgClass, TipQuestionnaireAnswersComponent, WhistleblowerIdentityComponent, TipFilesWhistleblowerComponent, WidgetWbFilesComponent, TipCommentsComponent, TranslateModule, TranslatorPipe]
+    imports: [TipAdditionalQuestionnaireInviteComponent, TipInfoComponent, TipReceiverListComponent, NgbTooltipModule, NgClass, TipQuestionnaireAnswersComponent, WhistleblowerIdentityComponent, TipFilesWhistleblowerComponent, WidgetWbFilesComponent, TipCommentsComponent, TipContactEmailComponent, TranslateModule, TranslatorPipe]
 })
 export class TippageComponent implements OnInit {
   private fieldUtilities = inject(FieldUtilitiesService);

--- a/client/app/src/shared/partials/tip-contact-email/tip-contact-email.component.html
+++ b/client/app/src/shared/partials/tip-contact-email/tip-contact-email.component.html
@@ -1,0 +1,15 @@
+<div id="TipContactEmailBox" class="card card-default" [attr.aria-expanded]="collapsed">
+  <div class="card-header" (click)="toggleCollapse(); utilsService.stopPropagation($event)">
+    <span>{{'Manage notifications'|translate}}</span>
+  </div>
+  @if (!collapsed) {
+    <div class="card-body">
+      <label for="contactEmailInput" class="form-label">{{'Contact email'|translate}}</label>
+      <input id="contactEmailInput" type="email" class="form-control" [(ngModel)]="email" />
+      <button class="btn btn-primary mt-2" (click)="updateEmail()" [disabled]="!email">
+        <i class="fa-solid fa-save"></i>
+        <span>{{'Save'|translate}}</span>
+      </button>
+    </div>
+  }
+</div>

--- a/client/app/src/shared/partials/tip-contact-email/tip-contact-email.component.ts
+++ b/client/app/src/shared/partials/tip-contact-email/tip-contact-email.component.ts
@@ -1,0 +1,36 @@
+import {Component, inject, OnInit} from "@angular/core";
+import {FormsModule} from "@angular/forms";
+import {WbtipService} from "@app/services/helper/wbtip.service";
+import {HttpService} from "@app/shared/services/http.service";
+import {UtilsService} from "@app/shared/services/utils.service";
+import {TranslateModule} from "@ngx-translate/core";
+import {TranslatorPipe} from "@app/shared/pipes/translate";
+
+@Component({
+    selector: "src-tip-contact-email",
+    templateUrl: "./tip-contact-email.component.html",
+    standalone: true,
+    imports: [FormsModule, TranslateModule, TranslatorPipe]
+})
+export class TipContactEmailComponent implements OnInit {
+  protected wbTipService = inject(WbtipService);
+  private httpService = inject(HttpService);
+  protected utilsService = inject(UtilsService);
+
+  email = '';
+  collapsed = false;
+
+  ngOnInit() {
+    this.email = this.wbTipService.tip?.data?.contact_email || '';
+  }
+
+  toggleCollapse() {
+    this.collapsed = !this.collapsed;
+  }
+
+  updateEmail() {
+    this.httpService.whistleBlowerContactEmailUpdate({contact_email: this.email}).subscribe(() => {
+      this.wbTipService.tip.data.contact_email = this.email;
+    });
+  }
+}

--- a/client/app/src/shared/services/http.service.ts
+++ b/client/app/src/shared/services/http.service.ts
@@ -273,6 +273,10 @@ export class HttpService {
     return this.httpClient.post<void>("api/whistleblower/wbtip/identity", param);
   }
 
+  whistleBlowerContactEmailUpdate(param: { contact_email: string }): Observable<void> {
+    return this.httpClient.post<void>("api/whistleblower/wbtip/contactemail", param);
+  }
+
   requestAdminFieldTemplateResource(): Observable<fieldtemplatesResolverModel[]> {
     return this.httpClient.get<fieldtemplatesResolverModel[]>("api/admin/fieldtemplates");
   }


### PR DESCRIPTION
## Summary
- allow storing a contact email via new endpoint
- notify whistleblowers when recipients update report status
- include contact email validation request format
- offer UI to set contact email on tip page

## Testing
- `pytest -q` *(fails: 73 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_685716c7ecac832a8f441140c08de5bf